### PR TITLE
Don't enable http1 feature in hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tcp = ["hyper/tcp"]
 
 [dependencies]
 http = "0.2"
-hyper = { git = "https://github.com/benesch/hyper.git", branch = "connectors-no-proto", default-features = false, features = ["client"] }
+hyper = { version = "0.14.2", default-features = false, features = ["client"] }
 linked_hash_set = "0.1"
 once_cell = "1.0"
 openssl = "0.10.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,12 @@ readme = "README.md"
 exclude = ["test/*"]
 
 [features]
-# FIXME should not be turning on http1 by default: https://github.com/hyperium/hyper/issues/2376
-default = ["hyper/http1", "tcp"]
-
+default = ["tcp"]
 tcp = ["hyper/tcp"]
 
 [dependencies]
 http = "0.2"
-hyper = { version = "0.14", default-features = false, features = ["client"] }
+hyper = { git = "https://github.com/benesch/hyper.git", branch = "connectors-no-proto", default-features = false, features = ["client"] }
 linked_hash_set = "0.1"
 once_cell = "1.0"
 openssl = "0.10.32"


### PR DESCRIPTION
This is aspirational at the moment, but wanted to validate that the upstream PR (hyperium/hyper#2377) works as intended. 

---

hyper has been fixed so that the "http1" feature is no longer necessary
to get the various connection types required by this crate.