### PR TITLE
Add rustc-check-cfg directive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@ use std::env;
 
 #[allow(clippy::unusual_byte_groupings)]
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(ossl102)");
+    println!("cargo:rustc-check-cfg=cfg(ossl111)");
     if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
         let version = u64::from_str_radix(&version, 16).unwrap();
 


### PR DESCRIPTION
Closes #43 by emitting a `rustc-check-cfg` directive to the compiler ([[relevant section of rustc book]](https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#cargorustc-check-cfg-for-buildrsbuild-script)).

Although the rustc book recommends using two colons, doing so in this repo gives this error when running `cargo check --tests`:

```
error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, but the minimum supported Rust version of `hyper-openssl v0.10.2 (/home/phoenix/repos/h3stuff/hyper-openssl)` is 1.68.
Switch to the old `cargo:rustc-check-cfg=cfg(ossl102)` syntax (note the single colon).
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```

Using a single colon for the "old syntax" seems to work with both of the following commands:

```sh 
cargo check --tests
#   Compiling hyper-openssl v0.10.2 (/home/phoenix/repos/h3stuff/hyper-openssl)
#    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
rustup install 1.68 && rm Cargo.lock && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +nightly -Zmsrv-policy generate-lockfile && cargo +1.68 check --tests
#info: syncing channel updates for '1.68-x86_64-unknown-linux-gnu'
#
#  1.68-x86_64-unknown-linux-gnu unchanged - rustc 1.68.2 (9eb3afe9e 2023-03-27)
#
#info: self-update is disabled for this build of rustup
#info: any updates to rustup will need to be fetched with your system package manager
#    Updating crates.io index
#     Locking 92 packages to latest Rust 1.68 compatible versions
#      Adding tokio v1.38.1 (available: v1.41.0, requires Rust 1.70)
#      Adding tokio-macros v2.3.0 (available: v2.4.0, requires Rust 1.70)
#      Adding tokio-util v0.7.11 (available: v0.7.12, requires Rust 1.70)
#   Compiling hyper-openssl v0.10.2 (/home/phoenix/repos/h3stuff/hyper-openssl)
#warning: cargo:rustc-check-cfg requires -Zcheck-cfg=output flag
#warning: cargo:rustc-check-cfg requires -Zcheck-cfg=output flag
#    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
```

(Random note: In the second command I am having to use the experimental [MSRV-aware resolver](https://github.com/rust-lang/cargo/issues/13873#issuecomment-2284833685') to get this compiling on Rust 1.68 due to a transitive dependency on tokio through hyper).